### PR TITLE
[PR-4] Feature: Common UI

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/site/components/footer.astro
+++ b/site/components/footer.astro
@@ -1,0 +1,9 @@
+<footer class="text-primary border-border w-full border-t">
+  <div
+    class="flex flex-col items-center justify-center gap-4 px-4 py-6 md:flex-row lg:justify-end lg:px-8"
+  >
+    <div class="text-center md:text-left">
+      <p class="text-muted mt-1 text-sm">© 2025 All rights reserved.</p>
+    </div>
+  </div>
+</footer>

--- a/site/components/header.astro
+++ b/site/components/header.astro
@@ -1,0 +1,40 @@
+<header
+  class="bg-primary-bg text-primary border-border sticky top-0 w-full border-b"
+>
+  <div class="flex items-center justify-between px-4 py-4 lg:px-8">
+    <a href="/" class="text-lg font-bold break-words sm:text-2xl"
+      >PATTERN RECOGNITION</a
+    >
+
+    <!-- info Mobile Toggle Menu -->
+    <details class="group relative md:hidden">
+      <summary class="text-primary hover:text-theme cursor-pointer">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="30"
+          viewBox="0 0 30 30"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M4 6h16M4 12h16M4 18h16"></path>
+        </svg>
+      </summary>
+      <nav
+        class={`
+        absolute top-0 right-0 -translate-x-1/2 z-10
+        flex w-fit flex-col gap-4 p-4 
+        group-open:opacity-100 opacity-0
+        transition-opacity duration-300 
+        bg-background border-primary text-primary 
+        rounded-sm border shadow-md`}
+      >
+        <a href="/" class="hover:text-theme">Home</a>
+        <a href="/algorithms" class="hover:text-theme">Algorithms</a>
+        <a href="/uiux" class="hover:text-theme">UI/UX</a>
+      </nav>
+    </details>
+  </div>
+</header>

--- a/site/components/sidebar.astro
+++ b/site/components/sidebar.astro
@@ -1,0 +1,42 @@
+<aside
+  class="bg-primary-bg text-primary border-border hidden h-screen w-64 border-r p-4 md:block"
+>
+  <nav class="flex flex-col gap-2">
+    <!-- TODO Dynamic contents injection from {@/{algorithms | uiux}}-->
+    <!-- Home -->
+    <a href="/" class="hover:text-secondary font-semibold">🏠 Home</a>
+
+    <!--  Algorithms (폴더) -->
+    <details class="group">
+      <summary
+        class="hover:text-secondary flex cursor-pointer items-center justify-between font-semibold"
+      >
+        📂 Algorithms
+        <span class="group-open:rotate-90">▶</span>
+      </summary>
+      <div class="mt-2 ml-4 flex flex-col gap-1">
+        <a href="/algorithms/sorting" class="hover:text-secondary">📄 Sorting</a
+        >
+        <a href="/algorithms/graph" class="hover:text-secondary">📄 Graph</a>
+        <a href="/algorithms/dp" class="hover:text-secondary"
+          >📄 Dynamic Programming</a
+        >
+      </div>
+    </details>
+
+    <!-- UI/UX (폴더) -->
+    <details class="group">
+      <summary
+        class="hover:text-secondary flex cursor-pointer items-center justify-between font-semibold"
+      >
+        🎨 UI/UX
+        <span class="group-open:rotate-90">▶</span>
+      </summary>
+      <div class="mt-2 ml-4 flex flex-col gap-1">
+        <a href="/uiux/buttons" class="hover:text-secondary">📄 Buttons</a>
+        <a href="/uiux/forms" class="hover:text-secondary">📄 Forms</a>
+        <a href="/uiux/grids" class="hover:text-secondary">📄 Grid Layouts</a>
+      </div>
+    </details>
+  </nav>
+</aside>

--- a/site/layouts/root-layout.astro
+++ b/site/layouts/root-layout.astro
@@ -1,0 +1,41 @@
+---
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+import Footer from "site/components/footer.astro";
+import Sidebar from "site/components/sidebar.astro";
+import Header from "site/components/header.astro";
+const { title, description } = Astro.props as Props;
+const titleString = `Pattern Recognition${title ? ` - ${title}` : ""}`;
+const descriptionString = description ? `${description}` : "";
+---
+
+<!doctype html>
+<html lang="kr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/site/global.css" />
+    <title>{titleString} Pattern Recognition</title>
+    <meta name="description" content={descriptionString} />
+  </head>
+  <body
+    class="bg-background text-primary flex min-h-dvh flex-col overflow-hidden"
+  >
+    <Header />
+    <div class="bg container flex max-h-[80dvh] grow">
+      <!-- info Side Nav -->
+      <Sidebar />
+      <!-- info 페이지 컨텐츠 컨테이너 -->
+      <main class="flex-1 p-4 sm:p-6">
+        <!-- info
+         {algo | uiux}.template injection
+         개별 페이지: 동적 컨텐츠 주입 -->
+        <slot />
+      </main>
+    </div>
+    <Footer />
+  </body>
+</html>

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -1,0 +1,9 @@
+---
+import BaseLayout from "site/layouts/root-layout.astro";
+---
+
+<BaseLayout title="HOME" description="Pattern Recognition Index">
+  <h1 class="text-theme text-2xl font-bold text-pretty sm:text-3xl">
+    UNDER CONSTRUCTION
+  </h1>
+</BaseLayout>


### PR DESCRIPTION
# [PR-3] Feature :  UI components 

## Scope:
- Index Page: `site/pages/index.astro` 
- Static Common UI: `site/{ components | layouts }` 

1. 인덱스 페이지 마크업 추가
2. 공용 레이아웃 - 페이지 레이아웃, 
3. 공용 컴포넌트 - 헤더, 푸터, 사이드 Nav 
4. 모바일 대응

---
# Challenge

[referrence](https://github.com/0teklee/pattern-recognition/blob/main/docs/DEV_PLAN.md)

**4.5 hr / 6 hrs**
**1.5** hours left

---
# Process & Reasoning
Demonstrate the reasoning of designing & composing common UIS
이번 PR의 공용 컴포넌트 설계 구성의 과정과 추론을 설명합니다.

## UI
<img width="1582" alt="스크린샷 2025-03-13 15 35 00" src="https://github.com/user-attachments/assets/2e929970-a7fc-47d6-9852-feff61cda3a9" />

## Design

**[Reference 참조](https://docs.astro.build/en/concepts/islands/#island-components)**

1. Astro의 Island Architecture를 참조하였습니다.
2. **Predeterminable(or Predicted) UI = Static UI**
    미리 결정될 수 있는 UI는 **마크업 + CSS** 만으로 구현합니다.
3. UI에서 동적인 컨텐츠 이외의 모든 부분을 정적으로 구현합니다.
      - `Astro`의 **Slot**, **Props** 기반으로 동적 컨텐츠를 주입합니다.
      - 그 외의 영역은 모든 페이지에서 동일하게 유지됩니다.
5. **Astro**의 **Layouts** 패턴을 참조해 반복되는 레이아웃을 미리 개발했습니다.
      - 각 page/*.astro에서 head 태그를 주입하도록 Props를 설정
      - 동적인 부분은 Slot으로 주입

_참조: 이 프로젝트에서 서버 렌더링은 **빌드 타임에 생성**되는 정적 컴포넌트입니다._

`** = included in this PR`
```
./site
├── components // Common UI components
│   ├── filter-dropdown.astro
│   ├── footer.astro **
│   ├── header.astro **
│   └── sidebar.astro ** // -> static layouts + will be partially dynamic later on
├── global.css // common tailwind stylesheet
├── layouts // ** common Layouts
│   ├── detail-layout.astro 
│   ├── list-layout.astro
│   └── root-layout.astro // ** IMPORTANT
├── pages
│   ├── index.astro** --> Root dir 
│   ├── uiux                      ----> uiux, algorithms => sub-root : will be added later PR
│    │    ├── [post].astro         
│    │    └── index.astro
│   └── algorithms
│       ├── [post].astro
│       └── index.astro
└── uiux ----> !!  list-template.astro => will get props from pages/uiux/{index | [post]}.astro 
    └── templates 
        ├── list-template.astro
        └── post-template.astro
```

## Screenshot

| Index       | Image                                                |
| ------------------------ | --------------------------------------------------------------------------------------------------------- |
| **Main(pc)*        | <img width="1582" alt="스크린샷 2025-03-13 15 35 00" src="https://github.com/user-attachments/assets/1fa2434b-89f4-452a-b863-deee1fd96752" />    |
| **Main (tablet)**    | <img width="847" alt="스크린샷 2025-03-13 15 35 04" src="https://github.com/user-attachments/assets/d2e18b4d-d6b9-4a57-ad07-51169553e4a2" />                                                     |
| **Main (mobile)**        | <img width="847" alt="스크린샷 2025-03-13 15 35 09" src="https://github.com/user-attachments/assets/60a1afd9-a69d-4caa-aa0d-67d5f67ddc3d" />   |
| **Header (mobile/data-open)**    | <img width="847" alt="스크린샷 2025-03-13 15 35 13" src="https://github.com/user-attachments/assets/91f70919-6031-434d-9b92-8a2d8a194eb7" />                                                                                           |