### PR TITLE
[PR-5] Refactor: TS Config + Astro Types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,13 @@
-import tseslint from "typescript-eslint";
 import eslintPluginAstro from "eslint-plugin-astro";
+import tseslint from "typescript-eslint";
 
 export default [
   ...tseslint.configs.recommended,
   ...eslintPluginAstro.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-empty-object-type": "off",
+    },
+    files: ["**/*.astro"],
+  },
 ];

--- a/site/types/domains.ts
+++ b/site/types/domains.ts
@@ -1,0 +1,9 @@
+enum Domains {
+  Index = "index",
+  Algorithms = "algorithms",
+  Uiux = "uiux",
+}
+
+type SubRoot = Exclude<Domains, Domains.Index>;
+
+export type { Domains, SubRoot };

--- a/site/types/index.d.ts
+++ b/site/types/index.d.ts
@@ -1,0 +1,3 @@
+export * from "./search-params";
+export * from "./props";
+export * from "./domain";

--- a/site/types/props.ts
+++ b/site/types/props.ts
@@ -1,0 +1,23 @@
+import type { HTMLAttributes } from "astro/types";
+import type { SearchParam } from "./search-params.ts";
+import type { Domains, SubRoot } from "./domains";
+
+// Inject meta title/description in @site/pages/*
+export interface MetaTagProps extends Omit<HTMLAttributes<"meta">, "dir"> {
+  title?: string;
+  description?: string;
+}
+
+/** Inject & Rendering {title | desc | searchParam}
+ *  in @site/pages/{algo | uiux}/index.astro **/
+export interface ContentListProps extends MetaTagProps {
+  dir: SubRoot;
+  searchParam?: SearchParam<SubRoot> | null;
+}
+
+export interface ContentMetaDataProps {
+  title: string;
+  createdAt: string;
+  tags: string[];
+  dir: [Domains, ...string[]];
+}

--- a/site/types/search-params.ts
+++ b/site/types/search-params.ts
@@ -1,0 +1,44 @@
+import type { Domains, SubRoot } from "./domains";
+
+type BaseSearchParam = "category" & ParamPattern;
+
+// 프로그래밍 언어 (js, ts ...tba)
+type ParamLang = "lang";
+
+// 릿코드, 프로그래머스 같은 코딩 플랫폼
+type ParamPlatform = "platform";
+
+// 난이도 (문제 난이도, 러닝 커브)
+type ParamLevel = "level";
+
+// 알고리즘 패턴, 디자인 패턴 관련 (Atomic Design, Island), 설계 패턴
+type ParamPattern = "pattern";
+
+// React (포함), Next.js, Astro, Vue, Svelt, ...TBA - beyond FE
+type ParamFramework = "framework";
+
+// UI 컴포넌트
+type ParamComponent = "components";
+
+// CSS, Animation, Runtime styling, tailwind, animation (GSAP, Framer Motion), ETC
+type ParamStyle = "style";
+
+// algorithms 전용 searchParam
+type AlgorithmSearchParam = ParamLang | ParamPlatform | ParamLevel;
+
+// UI/UX 전용 searchParam
+type UISearchParam = ParamFramework | ParamComponent | ParamStyle;
+
+// searchParam 타입: dir에 따라 달라짐
+type SearchParam<T extends SubRoot> = T extends Domains.Algorithms
+  ? BaseSearchParam | AlgorithmSearchParam
+  : T extends Domains.Uiux
+    ? BaseSearchParam | UISearchParam
+    : never;
+
+export type {
+  BaseSearchParam,
+  AlgorithmSearchParam,
+  UISearchParam,
+  SearchParam,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,22 @@
 {
   "extends": "astro/tsconfigs/base",
   "compilerOptions": {
-    "baseUrl": "./",
+    "baseUrl": ".",
     "paths": {
-      "@algorithms/*": ["site/algorithms/*"],
-      "@uiux/*": ["site/uiux/*"],
-      "@config/*": ["site/config/*"]
+      /** INFO @ as project root - global configs, build-deploy scripts **/
+      "@/*": ["*"],
+      "@scripts/*": [".github"],
+      "@settings/*": ["*.json", "*.mjs", "*.ts"],
+      "@doc/*": ["doc/*"],
+      /** Info @content is dynamic contents **/
+      "@content/*": ["algorithms/*", "uiux/*"],
+      /** Info @site is Astro related path
+      @site-{ config | types | ui } includes common modules
+      **/
+      "@site/*": ["site/*"],
+      "@site-config/*": ["site/config/*"],
+      "@site-types/*": ["site/types/*"],
+      "@site-ui/*": ["site/layouts/*", "site/components/*"]
     },
     "allowJs": true,
     "moduleResolution": "bundler",
@@ -17,8 +28,9 @@
       {
         "name": "@astrojs/ts-plugin"
       }
-    ]
+    ],
+    "verbatimModuleSyntax": true
   },
-  "include": ["site/**/*"],
-  "exclude": ["node_modules", "algorithms/*", "dist"]
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["node_modules", ".astro", "dist"]
 }


### PR DESCRIPTION
# [PR-5] Configuring TypeScript for Astro

1. tsconfig.json 수정 
2. /site/types 생성
3. eslint rule 수정 : `*.astro`에만 적용

---
# Challenge

[referrence](https://github.com/0teklee/pattern-recognition/blob/main/docs/DEV_PLAN.md)

**5 hr / 6 hrs**

*1* hours left

---
# Process & Reasoning
Demonstrate the reasoning of TYPE
이번 PR의 과정과 추론을 설명합니다.

| Before     &  After                                                |
| --------------------------------------- |
|  <img width="640" alt="스크린샷 2025-03-14 10 34 24" src="https://github.com/user-attachments/assets/afc1469b-1e96-461a-88c1-1c4f34a53ff5" />           |  
<img width="591" alt="스크린샷 2025-03-14 10 35 35" src="https://github.com/user-attachments/assets/03e399e5-83a7-46bb-9e81-bdd859911b54" /> |

## Purpose 목적

### Astro Global Types
0. 개발 생산성을 위해 작성했습니다. 
1. `/site/*`에서 공용으로 사용될 타입만 추가 했습니다. 
2. Astro TS 문법을 참고하여 공용 로직의 (**Props**, **URLSearchParam**, **pathname** 등) 작성했습니다.
3. 주석으로 모든 타입에 설명을 추가했습니다.

### tsconfig & eslint.config.mjs
1. `/site/*`의 모듈 경로를 직관적으로 표현했습니다.
2. 로컬 개발 환경에서 빌드되는 .astro에서 불필요한 타입은 제외했습니다.
3. `*.astro` 파일에서 인텔리센스와 적절한 타입 추론
   - IDE(WebStorm)에서 Astro Language Service를 활성화를 위한 TS, ESLINT config 수정
   - 적절한 Props 타입 인식 및 자동 Import 적용


## Screenshots
|  Types: Seach Param     |  Types: Base Props    |
| ------------------|--------------|
|  <img width="776" alt="스크린샷 2025-03-14 10 33 42" src="https://github.com/user-attachments/assets/b735b76e-6dce-4e88-84fe-35902643951d" />        |   <img width="847" alt="스크린샷 2025-03-14 10 33 59" src="https://github.com/user-attachments/assets/8e6db92f-190b-456c-90e9-e2fc822c959e" /> |
| Auto Import | <img width="400" alt="스크린샷 2025-03-14 10 37 47" src="https://github.com/user-attachments/assets/b8dac1ff-bddd-4354-871d-23bb51e7adac" /> |







