### PR TITLE
[PR-10]:Feature Dynamic Content Area

### DIFF
--- a/site/components/list.astro
+++ b/site/components/list.astro
@@ -1,0 +1,52 @@
+---
+import type { CollectionEntry } from "astro:content";
+import Tags from "site/components/tags.astro";
+import { SubRoutes } from "site/types/routes";
+
+interface Props {
+  items: Array<CollectionEntry<SubRoutes>>;
+}
+
+const { items } = Astro.props;
+const subRoute: SubRoutes = items[0]?.data.path[0];
+---
+
+<ol class="flex w-full flex-col gap-4 sm:gap-6">
+  {
+    items?.map((item) => {
+      // 태그 데이터 추출
+      const itemTags = item.data.tags || {};
+
+      const itemTagsValues = Object.values(item.data.tags || {})
+        .filter((tag) => tag && typeof tag === "string")
+        .join(",");
+
+      // 경로 데이터 추출 (필터링용)
+      const itemCategory = item.data.tags.category;
+
+      const itemDataAttr = Object.entries(itemTags).reduce(
+        (attrs, [key, value]) => {
+          attrs[`data-tag-${key}`] = value;
+          return attrs;
+        },
+        {},
+      );
+
+      return (
+        <li
+          id={item.data.id}
+          class="ring-theme group hover:border-theme w-full border-separate border-b py-2 transition-all duration-200 hover:ring sm:border-s-4 sm:border-b-0 sm:pl-3 md:py-3"
+          data-category={itemCategory}
+          data-tags={itemTagsValues}
+          {...itemDataAttr}
+        >
+          <a class="group-hover:text-theme" href={`/${subRoute}/${item.id}`}>
+            {item.data.title}
+          </a>
+          <Tags path={subRoute} tags={item.data.tags} size="sm" />
+          <p class="text-sm">{item.data?.description}</p>
+        </li>
+      );
+    })
+  }
+</ol>

--- a/site/components/post-header.astro
+++ b/site/components/post-header.astro
@@ -1,0 +1,21 @@
+---
+import Tags from "site/components/tags.astro";
+import { SearchParam } from "site/types/query";
+interface Props {
+  title: string;
+  createdAt: string;
+  tags: SearchParam<"index">;
+}
+
+const { title, createdAt, tags, path } = Astro.props;
+---
+
+<header class="border-border w-full border-b pb-6">
+  <h1 class="text-primary w-full text-2xl font-bold text-pretty sm:text-3xl">
+    {title}
+  </h1>
+  <div class="mt-1 space-y-4">
+    <p class="text-secondary text-sm">{createdAt}</p>
+    <Tags path={path[0]} tags={tags} size="base" />
+  </div>
+</header>

--- a/site/components/sidebar.astro
+++ b/site/components/sidebar.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from "astro:content";
+import { Routes } from "site/types/routes";
 
 const currentPathname = Astro.url.pathname;
 
@@ -9,11 +10,11 @@ const algorithmPosts =
 
 // UI/UX 콘텐츠 가져오기 - 스크립트 분기
 const uiuxPosts =
-  process.env.ALGO_BUILD === "true" ? [] : await getCollection("uiux");
+  process.env.ALGO_BUILD === "false" ? [] : await getCollection("uiux");
 
 function groupContentByFolder(posts) {
   if (posts.length === 0) {
-    return {};
+    return [];
   }
   // 폴더별 게시물 그룹화
   const folderGroups = {};
@@ -30,12 +31,11 @@ function groupContentByFolder(posts) {
       folderGroups[folder].push({
         id: post.id,
         title: post.data.title || post.id,
-        slug: post.id,
       });
     }
   });
 
-  return folderGroups;
+  return Object.entries(folderGroups);
 }
 
 const algoFolders = groupContentByFolder(algorithmPosts);
@@ -58,8 +58,11 @@ const uiuxFolders = groupContentByFolder(uiuxPosts);
         <span class="group-open:rotate-90">▶</span>
       </summary>
       <div class="mt-2 ml-4 flex flex-col gap-1">
+        <a href={Routes.algorithms} class="hover:text-secondary font-semibold"
+          >Index</a
+        >
         {
-          Object.entries(algoFolders).map(([folder, files]) => (
+          algoFolders.map(([folder, files]) => (
             <details class="group" open>
               <summary class="hover:text-secondary flex cursor-pointer items-center justify-between">
                 📁 {folder}
@@ -68,8 +71,8 @@ const uiuxFolders = groupContentByFolder(uiuxPosts);
               <div class="mt-1 ml-4 flex flex-col gap-1">
                 {files.map((file) => (
                   <a
-                    href={`/algorithms/${file.slug}`}
-                    class={`hover:text-secondary text-sm ${`/algorithms/${file.slug}` === currentPathname ? "text-theme" : ""} `}
+                    href={`/algorithms/${file.id}`}
+                    class={`hover:text-secondary text-sm ${`/algorithms/${file.id}` === currentPathname ? "text-theme" : ""} `}
                   >
                     📄 {file.title}
                   </a>
@@ -90,8 +93,11 @@ const uiuxFolders = groupContentByFolder(uiuxPosts);
         <span class="group-open:rotate-90">▶</span>
       </summary>
       <div class="mt-2 ml-4 flex flex-col gap-1">
+        <a href={Routes.uiux} class="hover:text-secondary font-semibold"
+          >Index</a
+        >
         {
-          Object.entries(uiuxFolders).map(([folder, files]) => (
+          uiuxFolders.map(([folder, files]) => (
             <details class="group">
               <summary class="hover:text-secondary flex cursor-pointer items-center justify-between">
                 📁 {folder}
@@ -100,10 +106,10 @@ const uiuxFolders = groupContentByFolder(uiuxPosts);
               <div class="mt-1 ml-4 flex flex-col gap-1">
                 {files.map((file) => (
                   <a
-                    href={`/uiux/${file.slug}`}
+                    href={`/uiux/${file.id}`}
                     class="hover:text-secondary text-sm"
                   >
-                    📄 {file.title}
+                    📄 {file.id}
                   </a>
                 ))}
               </div>

--- a/site/components/sidebar.astro
+++ b/site/components/sidebar.astro
@@ -1,13 +1,56 @@
+---
+import { getCollection } from "astro:content";
+
+const currentPathname = Astro.url.pathname;
+
+// 알고리즘 콘텐츠 가져오기
+const algorithmPosts =
+  process.env.ALGO_BUILD === "true" ? await getCollection("algorithms") : [];
+
+// UI/UX 콘텐츠 가져오기 - 스크립트 분기
+const uiuxPosts =
+  process.env.ALGO_BUILD === "true" ? [] : await getCollection("uiux");
+
+function groupContentByFolder(posts) {
+  if (posts.length === 0) {
+    return {};
+  }
+  // 폴더별 게시물 그룹화
+  const folderGroups = {};
+
+  posts.forEach((post) => {
+    const pathParts = post.id.split("/");
+    if (pathParts.length > 1) {
+      const folder = pathParts[0]; // 첫 번째 부분은 폴더 이름
+
+      if (!folderGroups[folder]) {
+        folderGroups[folder] = [];
+      }
+
+      folderGroups[folder].push({
+        id: post.id,
+        title: post.data.title || post.id,
+        slug: post.id,
+      });
+    }
+  });
+
+  return folderGroups;
+}
+
+const algoFolders = groupContentByFolder(algorithmPosts);
+const uiuxFolders = groupContentByFolder(uiuxPosts);
+---
+
 <aside
-  class="bg-primary-bg text-primary border-border hidden h-screen w-64 border-r p-4 md:block"
+  class="bg-primary-bg text-primary border-border hidden max-w-64 grow border-r p-4 md:block"
 >
   <nav class="flex flex-col gap-2">
-    <!-- TODO Dynamic contents injection from {@/{algorithms | uiux}}-->
     <!-- Home -->
     <a href="/" class="hover:text-secondary font-semibold">🏠 Home</a>
 
-    <!--  Algorithms (폴더) -->
-    <details class="group">
+    <!-- Algorithms 섹션 -->
+    <details class="group" open>
       <summary
         class="hover:text-secondary flex cursor-pointer items-center justify-between font-semibold"
       >
@@ -15,16 +58,30 @@
         <span class="group-open:rotate-90">▶</span>
       </summary>
       <div class="mt-2 ml-4 flex flex-col gap-1">
-        <a href="/algorithms/sorting" class="hover:text-secondary">📄 Sorting</a
-        >
-        <a href="/algorithms/graph" class="hover:text-secondary">📄 Graph</a>
-        <a href="/algorithms/dp" class="hover:text-secondary"
-          >📄 Dynamic Programming</a
-        >
+        {
+          Object.entries(algoFolders).map(([folder, files]) => (
+            <details class="group" open>
+              <summary class="hover:text-secondary flex cursor-pointer items-center justify-between">
+                📁 {folder}
+                <span class="group-open:rotate-90">▶</span>
+              </summary>
+              <div class="mt-1 ml-4 flex flex-col gap-1">
+                {files.map((file) => (
+                  <a
+                    href={`/algorithms/${file.slug}`}
+                    class={`hover:text-secondary text-sm ${`/algorithms/${file.slug}` === currentPathname ? "text-theme" : ""} `}
+                  >
+                    📄 {file.title}
+                  </a>
+                ))}
+              </div>
+            </details>
+          ))
+        }
       </div>
     </details>
 
-    <!-- UI/UX (폴더) -->
+    <!-- UI/UX 섹션 -->
     <details class="group">
       <summary
         class="hover:text-secondary flex cursor-pointer items-center justify-between font-semibold"
@@ -33,9 +90,26 @@
         <span class="group-open:rotate-90">▶</span>
       </summary>
       <div class="mt-2 ml-4 flex flex-col gap-1">
-        <a href="/uiux/buttons" class="hover:text-secondary">📄 Buttons</a>
-        <a href="/uiux/forms" class="hover:text-secondary">📄 Forms</a>
-        <a href="/uiux/grids" class="hover:text-secondary">📄 Grid Layouts</a>
+        {
+          Object.entries(uiuxFolders).map(([folder, files]) => (
+            <details class="group">
+              <summary class="hover:text-secondary flex cursor-pointer items-center justify-between">
+                📁 {folder}
+                <span class="group-open:rotate-90">▶</span>
+              </summary>
+              <div class="mt-1 ml-4 flex flex-col gap-1">
+                {files.map((file) => (
+                  <a
+                    href={`/uiux/${file.slug}`}
+                    class="hover:text-secondary text-sm"
+                  >
+                    📄 {file.title}
+                  </a>
+                ))}
+              </div>
+            </details>
+          ))
+        }
       </div>
     </details>
   </nav>

--- a/site/components/tags.astro
+++ b/site/components/tags.astro
@@ -1,0 +1,64 @@
+---
+import { SearchParam } from "site/types/query";
+import { RouteType } from "site/types/routes";
+
+interface Props {
+  tags: SearchParam<"index">;
+  path: RouteType;
+  size?: "sm" | "base";
+}
+
+const { tags, size = "base", path } = Astro.props;
+const arrTags = Object.entries(tags).filter(([key, val]) => !!key && !!val);
+---
+
+<div
+  id="tags-container"
+  class={`flex flex-wrap items-center mt-1 mb-2 gap-x-4 ${size === "sm" ? "text-xs" : "text-sm"}`}
+>
+  {
+    arrTags.map(([key, val]) =>
+      !!val
+        ? () => {
+            return (
+              <button
+                id={`${key}=${val}`}
+                class={`tag-button ${key} cursor-pointer rounded-sm ${size === "sm" ? "px-1 py-0" : "px-2 py-1"} `}
+                aria-description={`link to tag: ${key}`}
+                data-key={key}
+                data-value={val}
+              >
+                {val}
+              </button>
+            );
+          }
+        : null,
+    )
+  }
+</div>
+
+<script define:vars={{ path }}>
+  const buttonContainer = document.getElementById("tags-container");
+
+  const eventClick = (e) => {
+    const button = e.target.closest(".tag-button");
+    if (!button) return;
+
+    const key = button?.dataset.key;
+    const value = button?.dataset.value;
+    const params = new URLSearchParams(window.location.search);
+
+    if (params.get(key) === value) {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+
+    window.location.replace(`/${path}?${params.toString()}`);
+  };
+
+  buttonContainer.addEventListener("click", (e) => eventClick(e));
+  window.addEventListener("popstate", (e) => {
+    console.log("tag popstate", e);
+  });
+</script>


### PR DESCRIPTION
# [PR-10] Dynamic Content Area



## Demo

https://github.com/user-attachments/assets/89511db6-3a69-4c51-9009-89cafa1a40e8


1. Dynamic 영역 컨텐츠 UI [관련 PR](https://github.com/0teklee/pattern-recognition/pull/4)
2. 동적 컨텐츠의 Props 기반으로 재사용 컴포넌트 - `/algorithms`, `/uiux`
3. 사이드바 - 컨텐츠 폴더 구조와 맵핑된 `[...id].astro` 페이지의 URL 링크 리스트

---

# Process & Reasoning

빌드 타임에 컨텐츠 기반으로 생성되는 컴포넌트를 만들었습니다. 
이전 [PR-4](https://github.com/0teklee/pattern-recognition/pull/4)에 표시했던 동적 영역에서 재사용되는 컴포넌트를 작성했습니다. 
컨텐츠의 Props 기반으로 작성되었고, 컨텐츠 스키마가 동일한 형태이기 때문에 하나의 컴포넌트로 관리할 수 있습니다.
추후 변경이 생길 시, 분리할 예정입니다.

### List
이 컴포넌트는 모든 리스트 페이지에서 포스팅을 동일한 UI로 보여줍니다.

- `Props` : getCollection으로 컨텐츠 리스트를 그대로 넘겨받습니다.
- `SubRoute`: 컨텐츠 스키마의 path는 경로를 문자 배열로 갖고 있습니다. 
    - 이 배열의 첫 요소 `path[0]`은 `/algorithms | uiux`를 가리킵니다.
    - 이를 활용해 두 경로 모두에서 디테일 클릭 시 해당 경로의 디테일 페이지로 갈 수 있습니다.
- [itemAttrs](https://github.com/0teklee/pattern-recognition/compare/feature/apply-dynamic-area-with-content?expand=1#diff-5f593c4526ff34ad44988dae817d92d886dc12f3f674f40536a5854a01f4aafdR27)
    - `data-*`: 추후 리스트 필터링을 위해 컨텐츠 스키마의 태그, 카테고리 관련 커스텀 data-attribute을 추가했습니다.

### Sidebar
사이드바 Nav는 Algorithms | UIUX의 하위 경로를 보여줍니다. 
1. 현재 디테일 페이지가 속한 페이지의 하이라이트
2. 재귀적 폴더 구조 반영

### Tags (common)
모든 페이지에서 재사용되는 태그입니다. 
컨텐츠 스키마의 `tags` 필드(객체)를 기반으로 URLSearchParams를 추가해 이동합니다.

```js
const tags = {
   [key: QueryKeys] : "string"
}
```
쿼리 키 타입은 [query.ts](https://github.com/0teklee/pattern-recognition/pull/7/files#diff-483a8ef658c056c9bc27c36bf8d17014d5a51213d0b2e75a2d4f63d45582dc04)와 주석 [docs.ts](https://github.com/0teklee/pattern-recognition/pull/7/files#diff-ef42e5340d93f442c93ea790273a6c38af2d555690b0823e2fea1e5b457a701b)를 참조합니다.

### Post Header (common)
디테일 페이지의 헤더를 재사용합니다. 마찬가지로 컨텐츠 스키마의 정보를 Props로 받습니다.


| Screenshots       | 
| ------------------------ | 
| Before <img width="1582" alt="스크린샷 2025-03-13 15 35 00" src="https://github.com/user-attachments/assets/2e929970-a7fc-47d6-9852-feff61cda3a9" /> |
|  After <img width="1451" alt="스크린샷 2025-03-19 10 15 07" src="https://github.com/user-attachments/assets/45629e9d-b632-4369-bd13-4824a1e7dde6" />   |
