### PR TITLE
[PR-16] CICD : Integrate Github Actions + Cloudflare Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Build in GA and Deploy in CF
 on:
   push:
     branches:
@@ -29,8 +29,8 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
-          filters: "algorithms:\n- 'site/content/algorithms/**'\n- 'site/pages/algorithms/**'\n- 'site/components/**/!(uiux-*).astro'\nuiux:\n- 'site/content/uiux/**'\n- 'site/pages/uiux/**'\n- 'site/components/**/uiux-*.astro'\nconfigs:\n- 'site/config/**'\n- 'site/layouts/**'\ndeps:\n- 'package.json'\n- 'package-lock.json'  \n\"\n"
-  build:
+          filters: "algorithms:\n- 'site/content/algorithms/**'\n- 'site/pages/algorithms/**'\n- 'site/components/**/!(uiux-*).astro'\nuiux:\n- 'site/content/uiux/**'\n- 'site/pages/uiux/**'\n- 'site/components/**/uiux-*.astro'\nconfigs:\n- 'site/config/**'\n- 'site/layouts/**'\ndeps:\n- 'package.json'\n- 'package-lock.json'"
+  ga-build:
     needs: detect-changes
     runs-on: ubuntu-latest
     if: ${{ needs.detect-changes.outputs.algorithms == 'true' || needs.detect-changes.outputs.uiux == 'true' || needs.detect-changes.outputs.configs == 'true' || needs.detect-changes.outputs.deps == 'true' || github.event_name == 'workflow_dispatch' }}
@@ -45,37 +45,72 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build production
-        run: npm run build:prod
-      - name: Upload build artifacts
+        run: |
+          mkdir -p ${{ env.PRODUCTION_BUILD_PATH }}
+          echo "Setting ${{env.PRODUCTION_BUILD_PATH}}"
+          ls
+          echo "[BUILD]: PRD"
+          npm run build:prod
+          echo "[BUILD]: DONE. Scanning dist"
+          ls -R $PRODUCTION_BUILD_PATH
+
+      - name: Debug Artifact Path
+        run: |
+          echo "Checking production build path..."
+          ls -R ${{ env.PRODUCTION_BUILD_PATH }}
+
+      - name: Upload build artifacts - FINAL BLD STEP
         uses: actions/upload-artifact@v4
         with:
           name: production-build
           path: ${{ env.PRODUCTION_BUILD_PATH }}
-  deploy:
-    needs: build
+
+  push-prd-deploy-cf:
+    needs: ga-build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
     steps:
-      - name: Checkout production branch
+      - name: Checkout to production
         uses: actions/checkout@v4
         with:
           ref: production
+          fetch-depth: 0
+
+      - name: Check artifact before download
+        id: check-artifact
+        run: |
+          if [ -d "${{ env.PRODUCTION_BUILD_PATH }}" ]; then
+            echo "Artifact directory exists."
+          else
+            echo "[FAILED]:Artifact directory does not exist. Creating mkdir -p PRODUCTION_BUILD_PATH"
+            mkdir -p ${{ env.PRODUCTION_BUILD_PATH }}
+          fi
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: production-build
           path: ${{ env.PRODUCTION_BUILD_PATH }}
-      - name: Get main branch commit info
+
+      - name: Verify downloaded artifacts
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=format:"%s" ${{ github.sha }})
-          COMMIT_SHA=$(git rev-parse --short ${{ github.sha }})
-          TAG=$(git describe --tags --exact-match ${{ github.sha }} 2>/dev/null || echo "")
-          if [ -n "$TAG" ]; then
-            echo "COMMIT_MSG=Release $TAG: $COMMIT_MSG" >> $GITHUB_ENV
-          else
-            echo "COMMIT_MSG=build: $COMMIT_MSG ($COMMIT_SHA)" >> $GITHUB_ENV
+          ls -la ${{ env.PRODUCTION_BUILD_PATH }}
+          if [ -z "$(ls -A ${{ env.PRODUCTION_BUILD_PATH }})" ]; then
+            echo "WARN: build directory is empty. Creating new"
+            mkdir -p ${{ env.PRODUCTION_BUILD_PATH }}
+            echo "dist/production" > ${{ env.PRODUCTION_BUILD_PATH }}/placeholder.txt
           fi
-      - name: Commit and push to production
+
+      - name: Commit and push to production [FIN]
         run: |
+          git branch --show-current
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add ${{ env.PRODUCTION_BUILD_PATH }}
-          git commit -m "${{ env.COMMIT_MSG }}"
+          git commit -m "PRD: update production build from main branch" 
           git push origin production
+          echo "[DEPLOY]: GA Jobs Done"
+        env:
+          ACTIONS_PAT: ${{ secrets.ACTIONS_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ node_modules
 .DS_Store
 **/.DS_Store
 
-dist/dev
+dist

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:dev": "SCOPE=algo dotenv -e .env.build -- astro build --config site/config/base.config.ts --mode development --verbose",
     "build:algo": "SCOPE=algo dotenv -e .env.build -- astro build --config site/config/algorithms.config.ts --mode development --verbose",
     "build:uiux": "SCOPE=uiux dotenv -e .env.build -- astro build --config site/config/uiux.config.ts --mode development --verbose",
-    "build:prod": "SCOPE=prd algo dotenv -e .env.prod -- npm run build:algo:prod && npm run build:uiux:prod && npm run merge:builds",
+    "build:prod": "SCOPE=prd dotenv -e .env.prod -- astro build --config site/config/base.config.ts",
     "build:algo:prod": "SCOPE=algo dotenv -e .env.prod -- astro build --config site/config/algorithms.config.ts --mode production",
     "build:uiux:prod": "SCOPE=uiux dotenv -e .env.prod -- astro build --config site/config/uiux.config.ts --mode production",
     "merge:builds": "mkdir -p dist/production && cp -r dist/dev/build-algo/* dist/production/ && cp -r dist/dev/build-uiux/* dist/production/",

--- a/site/config/base.config.ts
+++ b/site/config/base.config.ts
@@ -33,7 +33,7 @@ const pathAlias = {
 export const baseConfig = {
   site: "https://patterns.leetekwoo.com",
   srcDir: "./site",
-  outDir: "dist/main",
+  outDir: "dist/production",
   scopedStyleStrategy: "class",
   integrations: [
     mdx({


### PR DESCRIPTION
# [PR-16] CICD Integrate Github Actions + Cloudflare Pages

1. **Github Actions와 Cloudflare Pages를 연동한 CICD 파이프라인 구성**
2. **Github Action에서 빌드한 결과물을 artifact로 업로드하고, production 브랜치로 자동 배포**
3. **Cloudflare Pages가 production 브랜치 업데이트만을 감지해 배포하도록 설정**

---

# Process & Reasoning
이번 PR의 과정과 추론을 설명합니다.
1. detect-changes job에서 프로젝트 파일 변경을 감지하여 어떤 작업을 수행할지 결정합니다.
2. ga-build job에서 변경이 있을 경우 npm을 이용해 프로젝트를 빌드하고, 결과물을 dist/production 경로에 저장하여 artifact로 업로드합니다.
3. push-prd-deploy-cf job에서 artifact를 다운로드하여 production 브랜치로 push하여 Cloudflare Pages가 이를 감지하고 배포를 수행합니다.


---

# Trouble Shootings

## 1. 경로 문제 
- Github Action의 artifact 경로가 환경마다 달라 혼란스러웠습니다.
- 특히 main에서 빌드된 artifact를 production 브랜치로 이동 후 찾지 못해 어려움이 있었습니다.
- checkout 과정 및 각 job 실행 환경에 따라 artifact가 저장된 경로를 설정하는 과정에서 복잡성을 겪었습니다.

## 2. 권한 문제 
- Github Actions와 Cloudflare Pages 간의 연동 과정에서 권한 설정 (ruleset, token 등) 
- 관련 에러 지점을 파악하는데 많은 시간이 소요되었습니다. 
- 이에 대해 트러블 슈팅을 반복적으로 진행했습니다.

## 3. Pages wrangle
- wrangler 사용을 최소화하고 Github Actions에서 미리 빌드를 마친 결과물을 Cloudflare Pages에 그대로 배포하는 방식을 목표했습니다. - 그러나 wrangler의 부재로 정확한 경로 설정과 권한 문제를 해결하는데 어려움이 있었습니다.
-  최종적으로 Cloudflare Pages의 루트 경로를 **dist**로 설정하고, **빌드 과정을 exit 0으로 스킵한 뒤**, 배포 스크립트에 **정확한 경로와 API TOKEN 설정을 통해 해결했습니다**.

