### PR TITLE
[PR-20]: Refactor Global setting config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,11 +1,3 @@
 {
-  "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
-  "overrides": [
-    {
-      "files": ["*.astro", "**/*.astro"],
-      "options": {
-        "parser": "astro"
-      }
-    }
-  ]
+  "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,29 +1,29 @@
 import eslintPluginAstro from "eslint-plugin-astro";
-import jsdoc from "eslint-plugin-jsdoc";
 import * as mdx from "eslint-plugin-mdx";
 import tseslint from "typescript-eslint";
 
 export default [
   ...tseslint.configs.recommended,
-  ...eslintPluginAstro.configs.recommended,
+  ...eslintPluginAstro.configs["flat/base"],
   {
     ...mdx.flat,
     processor: mdx.createRemarkProcessor({
       lintCodeBlocks: false,
+      ignoreYAML: true,
     }),
   },
   {
-    plugins: jsdoc,
+    files: ["**/*.mdx"],
     rules: {
-      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-unresolved": "off",
+      "@typescript-eslint/no-unused-vars": "off",
     },
-    files: ["**/*.astro", "**/*.d.ts"],
   },
   {
+    files: ["**/*.astro"],
     rules: {
+      "@typescript-eslint/no-empty-interface": "off",
       "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-empty-object-type": "off",
     },
-    files: ["**/types/*.ts", "**/*.d.ts", "**/*.mdx", "*.mdx"],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "dev": "dotenv -e .env.dev -- astro dev --config site/config/base.config.ts",
+    "dev": "SCOPE=prd dotenv -e .env.dev -- astro dev --config site/config/base.config.ts",
     "dev:algo": "SCOPE=algo dotenv -e .env.dev -- astro dev --config site/config/algorithms.config.ts  --force --mode development",
     "dev:uiux": "SCOPE=uiux dotenv -e .env.dev -- astro dev --config site/config/uiux.config.ts  --force --mode development",
     "build:dev": "SCOPE=algo dotenv -e .env.build -- astro build --config site/config/base.config.ts --mode development --verbose",
@@ -18,7 +18,7 @@
     "@astrojs/react": "^4.2.1",
     "@astrojs/ts-plugin": "^1.10.4",
     "@tailwindcss/cli": "^4.0.13",
-    "@tailwindcss/vite": "^4.0.13",
+    "@tailwindcss/vite": "^4.0.15",
     "astro": "^5.4.3",
     "astro-embed": "^0.9.0",
     "astro-seo": "^0.8.4",
@@ -28,6 +28,7 @@
     "mdx": "^0.3.1",
     "rehype-accessible-emojis": "^0.3.2",
     "rehype-shiki": "^0.0.9",
+    "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.13",
     "zod": "^3.24.2"
   },
@@ -52,7 +53,7 @@
     "jsdoc": "^4.0.4",
     "jsdoc-plugin-typescript": "^3.2.0",
     "prettier": "3.5.3",
-    "prettier-plugin-astro": "0.14.1",
+    "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-jsdoc": "^1.3.2",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "stylelint": "^16.15.0",

--- a/site/config/base.config.ts
+++ b/site/config/base.config.ts
@@ -25,7 +25,7 @@ const pathAlias = {
   "@site-ui/layouts": "/site/layouts",
   "@site-ui/components": "/site/components",
   "@content": "/site/content",
-  "@content:algorithms": "/site/content/algorithms",
+  "@content:algo": "/site/content/algorithms",
   "@content:uiux": "/site/content/uiux",
   "@globalStyle": "/site/global.css",
 };

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,9 +1,4 @@
 /** @type {import('stylelint').Config} */
 export default {
   extends: ["stylelint-config-tailwindcss", "stylelint-prettier/recommended"],
-  overrides: [
-    {
-      files: ["**/*.astro"],
-    },
-  ],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       /** INFO @ as project root - global configs, build-deploy scripts **/
       "@/*": ["*"],
       "@scripts/*": [".github"],
-      "@settings/*": ["*.json", "*.mjs", "*.ts"],
+      "@settings/*": ["*.json", "*.mjs", "@/*.ts"],
       "@doc/*": ["doc/*"],
 
       /** Info @site is Astro related path
@@ -18,10 +18,11 @@
       "@site-config/*": ["site/config/*"],
       "@site-types/*": ["site/types/*"],
       "@site-ui/*": ["site/layouts/*", "site/components/*"],
+
       /** Info @content is dynamic contents **/
       "@content/*": ["site/content/*"],
-      "@content:algorithms": ["site/content/algorithms"],
-      "@content:uiux": ["site/content/uiux"]
+      "@content:algo": ["site/content/algorithms/*"],
+      "@content:uiux": ["site/content/uiux/*"]
     },
     "moduleResolution": "bundler",
     "module": "ESNext",
@@ -33,8 +34,15 @@
         "name": "@astrojs/ts-plugin"
       }
     ],
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true
   },
-  "include": [".astro/types.d.ts", "**/*" ],
-  "exclude": ["node_modules", ".astro", "dist"]
+  "include": [
+    ".astro/types.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.astro",
+    "**/*.mdx"
+  ],
+  "exclude": ["node_modules", "dist", ".astro/*"]
 }


### PR DESCRIPTION
# [PR-20] 린트 설정 최적화 및 MDX 규칙 조정

1. ESLint, Prettier, Stylelint 설정 간소화
2. MDX 파일에 대한 린트 규칙 개선
3. 불필요한 override 설정 제거

---

# 작업 내용 및 이유

## 1. ESLint 설정 구조 변경

`.eslintrc` 대신 플랫 설정 방식으로 변경하고 파일별 규칙을 명확히 분리했습니다:

```javascript
// 변경 전: 복잡한 중첩 구조
...eslintPluginAstro.configs.recommended,

// 변경 후: 플랫 구조로 단순화
...eslintPluginAstro.configs["flat/base"],
```

목적:
- ESLint v8의 플랫 설정 형식 활용으로 설정 파일 간소화
- 파일 타입별 규칙 적용 명확화
- 불필요한 jsdoc 플러그인 의존성 제거

## 2. MDX 파일 린트 규칙 개선

MDX 파일 특성에 맞는 린트 규칙 추가:

```javascript
{
  files: ["**/*.mdx"],
  rules: {
    "@typescript-eslint/no-unresolved": "off",
    "@typescript-eslint/no-unused-vars": "off",
  },
},

// MDX 프로세서 설정 추가
processor: mdx.createRemarkProcessor({
  lintCodeBlocks: false,
  ignoreYAML: true,
}),
```

목적:
- frontmatter YAML 무시 설정으로 불필요한 경고 제거
- MDX 내 코드 블록과 JSX 표현식 관련 오류 억제
- 문서 작성 워크플로우 방해 요소 최소화

## 3. 불필요한 override 설정 제거

Prettier와 Stylelint의 불필요한 override 설정을 제거했습니다:

```javascript
// 제거된 Prettier 설정
"overrides": [
  {
    "files": ["*.astro", "**/*.astro"],
    "options": {
      "parser": "astro"
    }
  }
]

// 제거된 Stylelint 설정
overrides: [
  {
    files: ["**/*.astro"],
  },
],
```

목적:
- Prettier의 최신 버전에서는 자동으로 astro 파일 감지 가능
- 불필요한 중복 설정 제거로 린트 설정 간소화
- 설정 파일 유지보수 부담 감소