### PR TITLE
[PR-26]:Refactor env separation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
   "scripts": {
-    "dev": "SCOPE=prd dotenv -e .env.dev -- astro dev --config site/config/base.config.ts",
-    "dev:algo": "SCOPE=algo dotenv -e .env.dev -- astro dev --config site/config/algorithms.config.ts  --force --mode development",
-    "dev:uiux": "SCOPE=uiux dotenv -e .env.dev -- astro dev --config site/config/uiux.config.ts  --force --mode development",
-    "build:dev": "SCOPE=prd dotenv -e .env.build -- astro build --config site/config/base.config.ts --mode development --verbose",
-    "build:algo": "SCOPE=algo dotenv -e .env.build -- astro build --config site/config/algorithms.config.ts --mode development --verbose",
-    "build:uiux": "SCOPE=uiux dotenv -e .env.build -- astro build --config site/config/uiux.config.ts --mode development --verbose",
-    "build:prod": "SCOPE=prd dotenv -e .env.prod -- astro build --config site/config/base.config.ts",
-    "build:algo:prod": "SCOPE=algo dotenv -e .env.prod -- astro build --config site/config/algorithms.config.ts --mode production",
-    "build:uiux:prod": "SCOPE=uiux dotenv -e .env.prod -- astro build --config site/config/uiux.config.ts --mode production",
-    "merge:builds": "mkdir -p dist/production && cp -r dist/dev/build-algo/* dist/production/ && cp -r dist/dev/build-uiux/* dist/production/",
-    "preview:prd": "SCOPE=prd dotenv -e .env.build -- astro preview --config site/config/base.config.ts --site http://localhost:4321/dist/dev --force --mode development --verbose",
-    "preview:algo": "SCOPE=algo dotenv -e .env.build -- astro preview --config site/config/algorithms.config.ts --site http://localhost:4321/dist/dev/build-algo --force --mode development --verbose",
-    "preview:uiux": "SCOPE=uiux dotenv -e .env.build -- astro preview --config site/config/uiux.config.ts --site http://localhost:4321/dist/dev/build-uiux --force --mode development --verbose"
+    "dev": "dotenv -e .env.dev -- astro dev --config site/config/base.config.ts",
+    "dev:algo": "dotenv -e .env.dev.algo -- astro dev --config site/config/algorithms.config.ts  --force --mode development",
+    "dev:uiux": "dotenv -e .env.dev.uiux -- astro dev --config site/config/uiux.config.ts  --force --mode development",
+    "build:dev": "dotenv -e .env.build -- astro build --config site/config/base.config.ts --mode development --verbose",
+    "build:dev-algo": "dotenv -e .env.build -- astro build --config site/config/algorithms.config.ts --mode development --verbose",
+    "build:dev-uiux": "dotenv -e .env.build -- astro build --config site/config/uiux.config.ts --mode development --verbose",
+    "build:prod": "dotenv -e .env.prod -- astro build --config site/config/base.config.ts",
+    "build:algo-prod": "dotenv -e .env.prod -- astro build --config site/config/algorithms.config.ts --mode production",
+    "build:uiux-prod": "dotenv -e .env.prod -- astro build --config site/config/uiux.config.ts --mode production",
+    "preview:dev": "dotenv -e .env.dev -- astro preview --config site/config/base.config.ts --site $PREVIEW_PORT --force --mode development --verbose",
+    "preview:prod": "dotenv -e .env.prod -- astro preview --config site/config/base.config.ts --site $PREVIEW_PORT --force --mode production --verbose",
+    "preview:algo": "dotenv -e .env.dev.algo -- astro preview --config site/config/algorithms.config.ts --site http://localhost:$PREVIEW_PORT/dist/dev/build-algo --force --mode development --verbose",
+    "preview:uiux": "dotenv -e .env.dev.uiux -- astro preview --config site/config/uiux.config.ts --site http://localhost:$PREVIEW_PORT/dist/dev/build-uiux --force --mode development --verbose"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.1.1",

--- a/site/components/sidebar.astro
+++ b/site/components/sidebar.astro
@@ -17,13 +17,13 @@ import { Routes } from "@site-types/routes";
 const currentPathname = Astro.url.pathname;
 
 //  콘텐츠 가져오기
-const { isPrd, isAlgo, isUIUX } = getEnv();
+const { isRoot, isAlgo, isUIUX } = getEnv();
 
 const collections = await Promise.all([
-  isAlgo || isPrd
+  isAlgo || isRoot
     ? getCollection("algorithms")
     : ([] as CollectionEntry<"algorithms">),
-  isUIUX || isPrd ? getCollection("uiux") : ([] as unknown[]),
+  isUIUX || isRoot ? getCollection("uiux") : ([] as unknown[]),
 ]);
 
 const [algoFolders, uiuxFolders] = collections.map((collection) =>

--- a/site/config/base.config.ts
+++ b/site/config/base.config.ts
@@ -32,12 +32,12 @@ const pathAlias = {
   "@globalStyle": "/site/global.css",
 };
 
-const { isPrd } = getEnv();
+const { isRoot } = getEnv();
 
 export const baseConfig = {
   site: "https://patterns.leetekwoo.com",
   srcDir: "./site",
-  outDir: isPrd ? "dist/production" : "dist/dev",
+  outDir: isRoot ? "dist/production" : "dist/dev",
   scopedStyleStrategy: "class",
   integrations: [
     mdx({
@@ -47,7 +47,7 @@ export const baseConfig = {
       remarkRehype: { footnoteLabel: "Footnotes" },
       gfm: false,
     }),
-    ...(isPrd ? [react()] : []),
+    ...(isRoot ? [react()] : []),
   ],
   vite: {
     resolve: {

--- a/site/pages/algorithms/[...id].astro
+++ b/site/pages/algorithms/[...id].astro
@@ -8,10 +8,10 @@ import { RouteKeyMap } from "../../types/routes";
 import { getEnv } from "../../utils";
 
 export const getStaticPaths = (async () => {
-  const { isPrd, isAlgo } = getEnv();
+  const { isRoot, isAlgo } = getEnv();
 
   const posts =
-    isPrd || isAlgo ? await getCollection(RouteKeyMap.algorithms) : [];
+    isRoot || isAlgo ? await getCollection(RouteKeyMap.algorithms) : [];
 
   return posts.map((post) => ({
     params: { id: post.id },

--- a/site/pages/algorithms/index.astro
+++ b/site/pages/algorithms/index.astro
@@ -9,9 +9,9 @@ import { getEnv } from "@site/utils";
 
 export const prerender = true;
 
-const { isPrd, isAlgo } = getEnv();
+const { isRoot, isAlgo } = getEnv();
 const posts =
-  isPrd || isAlgo ? await getCollection(RouteKeyMap.algorithms) : [];
+  isRoot || isAlgo ? await getCollection(RouteKeyMap.algorithms) : [];
 ---
 
 <BaseLayout title="Algorithms" description="Pattern Recognition - Algorithms">

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -8,13 +8,13 @@ import TabPanel from "@site-ui/tab-panel.astro";
 import index from "eslint-plugin-jsdoc";
 import { collections } from "../content/config";
 
-const { isPrd, isAlgo, isUIUX } = getEnv();
+const { isRoot, isAlgo, isUIUX } = getEnv();
 
 const [algoCollection, uiuxCollection] = await Promise.all([
-  isAlgo || isPrd
+  isAlgo || isRoot
     ? getCollection(RouteKeyMap.algorithms)
     : ([] as CollectionEntry<RouteKeyMap.algorithms>),
-  isUIUX || isPrd ? getCollection(RouteKeyMap.uiux) : ([] as unknown[]),
+  isUIUX || isRoot ? getCollection(RouteKeyMap.uiux) : ([] as unknown[]),
 ]);
 
 console.log("Algo Collection", algoCollection);

--- a/site/pages/uiux/[...id].astro
+++ b/site/pages/uiux/[...id].astro
@@ -11,9 +11,9 @@ import { getCollection, render } from "astro:content";
 import PostHeader from "site/components/post-header.astro";
 
 export const getStaticPaths = (async () => {
-  const { isPrd, isUIUX } = getEnv();
+  const { isRoot, isUIUX } = getEnv();
 
-  const posts = isPrd || isUIUX ? await getCollection("uiux") : [];
+  const posts = isRoot || isUIUX ? await getCollection("uiux") : [];
 
   return posts.map((post) => ({
     params: { id: post.id },

--- a/site/pages/uiux/index.astro
+++ b/site/pages/uiux/index.astro
@@ -7,8 +7,8 @@ import { getCollection } from "astro:content";
 import { getEnv } from "@site/utils";
 import { RouteKeyMap } from "../../types/routes";
 
-const { isPrd, isUIUX } = getEnv();
-const posts = isPrd || isUIUX ? await getCollection(RouteKeyMap.uiux) : [];
+const { isRoot, isUIUX } = getEnv();
+const posts = isRoot || isUIUX ? await getCollection(RouteKeyMap.uiux) : [];
 ---
 
 <BaseLayout title="UIUX" description="Pattern Recognition - UI/UX">

--- a/site/utils.ts
+++ b/site/utils.ts
@@ -1,5 +1,6 @@
 export const getEnv = () => ({
-  isPrd: process.env.SCOPE === "prd",
-  isAlgo: process.env.SCOPE === "algo",
-  isUIUX: process.env.SCOPE === "uiux",
+  isRoot:
+    process.env.NODE_ENV === "dev" || process.env.NODE_ENV === "production",
+  isAlgo: process.env.NODE_ENV === "dev:algo",
+  isUIUX: process.env.NODE_ENV === "dev:uiux",
 });


### PR DESCRIPTION
# [PR-26] 환경 변수 시스템 개선 및 스코프 단순화

1. 환경 변수 관리 방식 개선
2. 프로덕션 스코프 제거 및 환경값 업데이트
3. 서버 사이드 로컬 환경 변수 처리 방식 변경


---
# 작업 내용 및 이유

## 프로덕션 스코프 제거

불필요한 'prd' 스코프를 제거하고 환경값과 빌드, 배포 스크립트를 단순화했습니다:

```diff
- "build:prod": "SCOPE=prd dotenv -e .env.prod ..."
+ "build:prod": "dotenv -e .env.prod ...."
```

목적:
- 빌드 프로세스 단순화
- 환경 구분을 development/production으로 구분
- 추후 개발 파이프라인 구축 준비 - dev 브랜치 preview CI/CD 활용

